### PR TITLE
docs: add training wizard project plan

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -7,3 +7,13 @@
 **Docs:** README and docs scaffolding updated.  
 **Rollback Plan:** Restore previous state from Git history prior to this commit.  
 **Refs:** N/A
+
+## [2025-10-04 12:00] Draft training wizard project plan
+**Change Type:** Standard Change  
+**Why:** Document the redesign strategy for the upcoming training wizard.  
+**What changed:** Added a detailed project plan outlining vision, user flows, architecture, and milestones; linked the plan from the README.  
+**Impact:** Provides alignment for future development; no functional changes yet.  
+**Testing:** Documentation only; no tests required.  
+**Docs:** README and docs updated.  
+**Rollback Plan:** Remove `docs/project-plan.md` and revert README and changelog updates.  
+**Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ VisionTrain is a clean slate for future tooling around LoRA training workflows.
 
 ## Features
 - Repository baseline reset; no operational features are available yet.
+- Project plan for the upcoming Gradio-based training wizard captured in [`docs/project-plan.md`](docs/project-plan.md).
 
 ## Quick Start
 ```bash
@@ -16,7 +17,7 @@ VisionTrain is a clean slate for future tooling around LoRA training workflows.
 | _None_ | – | Configuration will be defined alongside future features. |
 
 ## Usage
-Usage instructions will be added once new tooling is implemented. See the `docs/` directory for upcoming design notes.
+Usage instructions will be added once new tooling is implemented. See [`docs/project-plan.md`](docs/project-plan.md) for the end-to-end training wizard roadmap.
 
 ## Development
 - Open an issue before introducing new training scripts or integrations.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1,0 +1,88 @@
+# VisionTrain Training Wizard Project Plan
+
+## Vision and Goals
+- Deliver an easy-to-use training experience focused on Low-Rank Adaptation (LoRA) for Stable Diffusion text-to-image models.
+- Embrace a modern, compact interface built with the latest Gradio components and a guided wizard-style workflow.
+- Support the core training domains: SD1.5, SDXL, PonyXL, and Illustration-focused fine-tuning.
+- Provide a responsive, self-service tool that handles base-model acquisition and exposes training control at the right depth for each user mode.
+
+## Guiding Principles
+1. **Simplicity first:** Surface only the essential decisions at each step while keeping defaults sensible and discoverable.
+2. **Progressive disclosure:** Offer an "Easy" mode for quick starts and an "Advanced" mode for full parameter control.
+3. **Responsiveness:** Communicate model downloads, validation, and training status with real-time feedback dialogs.
+4. **Safety and reproducibility:** Capture user choices for auditability, reproducibility, and reruns.
+
+## User Personas
+| Persona | Needs | Wizard Mode Fit |
+| --- | --- | --- |
+| Hobbyist creator | Quick setup, curated defaults, minimal terminology. | Easy |
+| Indie artist | Ability to tweak datasets, schedules, and logging while still guided. | Easy → Advanced |
+| ML engineer | Full control over hyperparameters, resource allocation, and callbacks. | Advanced |
+
+## Scope Overview
+| Track | Description | Outcomes |
+| --- | --- | --- |
+| UX & Wizard Flow | Define screens, questions, and branching logic for Easy vs. Advanced. | Wireframes, interaction specs, copy guidelines. |
+| Training Engine | Implement LoRA training pipelines for SD1.5, SDXL, PonyXL, and Illustration presets. | Modular training back-end with shared abstractions. |
+| Model Handling | Automate downloading, caching, and selection of base models with download progress dialogs. | Reliable model registry and responsive UI feedback. |
+| Platform & Ops | Package as a Gradio app with deployable configuration, logging, and monitoring. | Reproducible dev/prod setups. |
+| Documentation & Support | Provide quick-start guides, FAQs, and onboarding flows. | Updated README and supporting docs. |
+
+## Wizard Experience Blueprint
+1. **Landing / Mode Selection**
+   - Explain Easy vs. Advanced modes; remember last choice.
+2. **Dataset Intake**
+   - Questions about dataset location, format, and augmentation needs.
+   - Easy mode uses presets (e.g., recommended captioning) while Advanced exposes batch size, shuffle, and validation split.
+3. **Model & Objective Selection**
+   - Options: SD1.5, SDXL, PonyXL, Illustration.
+   - Auto-download base model with live progress dialog; allow manual path override in Advanced.
+4. **Training Configuration**
+   - Easy mode: learning rate, steps, and scheduler via guided choices with explanations.
+   - Advanced: full hyperparameter matrix including optimizer, precision, LoRA rank, regularization prompts, and logging cadence.
+5. **Resource Planning**
+   - GPU selection, mixed precision toggles, gradient accumulation.
+   - Easy mode sets defaults based on detected hardware.
+6. **Review & Confirm**
+   - Summarize all selections, highlight defaults, and allow edits.
+7. **Run & Monitor**
+   - Display training progress, ETA, and checkpoints.
+   - Notify on model downloads, checkpoint saves, and completion.
+
+## Technical Architecture
+- **Frontend:** Gradio 4.x leveraging Blocks, Tabs, Accordions for compact layout; custom CSS for modern visual tone.
+- **State Management:** Central wizard state object persisted per session; mode-aware validation for branching.
+- **Training Backend:** Python services wrapping diffusers/LoRA tooling with pluggable configs per base model.
+- **Model Registry:** YAML/JSON manifest describing supported models, source URLs, hashes, and default hyperparameters.
+- **Download Service:** Async downloader with progress callbacks feeding UI dialogs.
+- **Persistence:** Optional storage of runs, logs, and artifacts in a workspace directory with export support.
+
+## Milestones & Deliverables
+| Sprint | Focus | Key Deliverables |
+| --- | --- | --- |
+| 1 | Research & UX Foundations | Wireframes, copy draft, technical spikes for Gradio wizard patterns. |
+| 2 | Wizard Skeleton & Model Registry | Mode selection flow, model manifest implementation, download progress dialog prototype. |
+| 3 | Easy Mode Training Path | End-to-end Easy mode with SD1.5 preset; automated base-model download and training kickoff. |
+| 4 | Advanced Mode Extensions | Full hyperparameter control, dataset fine-tuning options, validation hooks. |
+| 5 | Additional Model Presets | SDXL, PonyXL, Illustration profiles with curated defaults and guidance text. |
+| 6 | Polish & Launch Readiness | QA, documentation updates, telemetry hooks, packaging for deployment. |
+
+## Risks & Mitigations
+| Risk | Mitigation |
+| --- | --- |
+| Large model downloads impact UX. | Stream progress updates, allow resumable downloads, surface estimated times. |
+| User confusion over parameters. | Provide contextual help tooltips, glossary links, and sensible defaults. |
+| Hardware variability. | Detect GPU capabilities, offer fallbacks (CPU warnings), document requirements. |
+| Maintenance burden for presets. | Centralize defaults in manifests and add automated checks for stale URLs. |
+
+## Success Metrics
+- Time-to-first-training run under 10 minutes for Easy mode users.
+- 90% successful model download completion without manual intervention.
+- User feedback rating of ≥4/5 for clarity and simplicity after pilot testing.
+- Ability to re-run a saved configuration with identical outcomes.
+
+## Next Steps
+1. Validate requirements with stakeholders and incorporate feedback.
+2. Prioritize sprint backlog, assign owners, and establish ceremonies.
+3. Draft technical RFCs for training backend abstractions and downloader service.
+4. Begin Sprint 1 activities per milestones.


### PR DESCRIPTION
## Why
- Provide a shared blueprint for the redesigned VisionTrain wizard experience.

## What
- Added a comprehensive project plan covering vision, flows, architecture, milestones, and risks.
- Linked the plan from the README so contributors can discover the roadmap.
- Logged the update in the changelog.

## Impact
- Aligns contributors on priorities and upcoming milestones; no runtime changes.

## Testing
- Not applicable (documentation-only change).

## Docs
- README updated with plan reference.

## Changelog
## [2025-10-04 12:00] Draft training wizard project plan
**Change Type:** Standard Change  
**Why:** Document the redesign strategy for the upcoming training wizard.  
**What changed:** Added a detailed project plan outlining vision, user flows, architecture, and milestones; linked the plan from the README.  
**Impact:** Provides alignment for future development; no functional changes yet.  
**Testing:** Documentation only; no tests required.  
**Docs:** README and docs updated.  
**Rollback Plan:** Remove `docs/project-plan.md` and revert README and changelog updates.  
**Refs:** N/A

------
https://chatgpt.com/codex/tasks/task_e_68e0ed65f19083339a1ff89e085af99f