### PR TITLE
docs: align README with project plan

### DIFF
--- a/Changelog/Changelog.md
+++ b/Changelog/Changelog.md
@@ -17,3 +17,13 @@
 **Docs:** README and docs updated.  
 **Rollback Plan:** Remove `docs/project-plan.md` and revert README and changelog updates.  
 **Refs:** N/A
+
+## [2025-10-04 09:56] Refresh README to match project direction
+**Change Type:** Standard Change  
+**Why:** Document the current vision and roadmap while the implementation is underway.  
+**What changed:** Rewrote the README to highlight planned wizard features, clarify project status, and point contributors to the project plan.  
+**Impact:** Documentation only; no functional code is affected.  
+**Testing:** Not applicable (documentation update).  
+**Docs:** README updated.  
+**Rollback Plan:** Revert README to the previous version and remove this changelog entry.  
+**Refs:** N/A

--- a/README.md
+++ b/README.md
@@ -1,27 +1,36 @@
 # VisionTrain
 
-VisionTrain is a clean slate for future tooling around LoRA training workflows.
+VisionTrain will deliver a guided Gradio wizard for training LoRA adapters on popular Stable Diffusion base models.
 
 ## Features
-- Repository baseline reset; no operational features are available yet.
-- Project plan for the upcoming Gradio-based training wizard captured in [`docs/project-plan.md`](docs/project-plan.md).
+- Dual-mode (Easy and Advanced) workflow that balances quick starts with full hyperparameter control.
+- Model registry and downloader pipeline for SD1.5, SDXL, PonyXL, and illustration-focused presets.
+- Real-time progress feedback for model downloads and training runs.
+- Transparent baseline: implementation is being built out according to the [project plan](docs/project-plan.md).
 
 ## Quick Start
 ```bash
-# Functionality has been removed pending the new implementation.
+# Implementation in progress.
+# Track scope, milestones, and open tasks in docs/project-plan.md.
 ```
 
 ## Configuration
 | Variable | Default | Notes |
 | --- | --- | --- |
-| _None_ | – | Configuration will be defined alongside future features. |
+| _TBD_ | – | Configuration keys will be defined alongside the upcoming Gradio implementation. |
 
 ## Usage
-Usage instructions will be added once new tooling is implemented. See [`docs/project-plan.md`](docs/project-plan.md) for the end-to-end training wizard roadmap.
+VisionTrain will provide a step-by-step wizard that handles dataset intake, model selection, configuration, and run monitoring.
+Refer to the [project plan](docs/project-plan.md) for the end-to-end experience design and milestone roadmap.
 
 ## Development
-- Open an issue before introducing new training scripts or integrations.
-- Add automated tests and linting alongside new functionality.
+- Align new issues and contributions with the milestones defined in `docs/project-plan.md`.
+- Propose architecture or UX changes via short RFCs before implementation.
+- Add automated tests, linting, and documentation alongside new functionality.
+
+## Documentation
+- High-level strategy: [`docs/project-plan.md`](docs/project-plan.md)
+- Additional guides will be added as features land.
 
 ## Changelog
 See [`Changelog/Changelog.md`](Changelog/Changelog.md).


### PR DESCRIPTION
## Why
- communicate the current product vision while implementation is underway

## What
- rewrote the README to highlight the planned wizard experience, model coverage, and contributor guidance
- linked the README back to the existing project plan for roadmap details

## Impact
- documentation only; no functional behavior

## Testing
- n/a (docs only)

## Docs
- README updated

## Changelog
## [2025-10-04 09:56] Refresh README to match project direction
**Change Type:** Standard Change  
**Why:** Document the current vision and roadmap while the implementation is underway.  
**What changed:** Rewrote the README to highlight planned wizard features, clarify project status, and point contributors to the project plan.  
**Impact:** Documentation only; no functional code is affected.  
**Testing:** Not applicable (documentation update).  
**Docs:** README updated.  
**Rollback Plan:** Revert README to the previous version and remove this changelog entry.  
**Refs:** N/A

------
https://chatgpt.com/codex/tasks/task_e_68e0ef4a9b7c8333ba1517698469f5bb